### PR TITLE
Support templated classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can see more examples in the [test](test) directory, where each `.hpp` file 
 ### Known Limitations
 
 C++ is a huge language, so the code generator is a work in progress.  Although improvements are made constantly, it currently can't handle the following important categories:
-- most template code
+- templates with non-type parameters
 - STL containers other than `vector` and `string`
 - array arguments
 

--- a/lib/RamFuzz.cpp
+++ b/lib/RamFuzz.cpp
@@ -718,7 +718,7 @@ void RamFuzz::run(const MatchFinder::MatchResult &Result) {
     outh << "  // True if obj was successfully internally created.\n";
     outh << "  operator bool() const { return obj; }\n";
     unordered_map<string, unsigned> namecount;
-    bool ctrs = false;
+    size_t ccount = 0;
     string safectr;
     for (auto M : C->methods()) {
       if (isa<CXXDestructorDecl>(M) || M->getAccess() != AS_public ||
@@ -729,7 +729,7 @@ void RamFuzz::run(const MatchFinder::MatchResult &Result) {
       if (isa<CXXConstructorDecl>(M)) {
         outh << "  " << cls << "* ";
         *outt << cls << "* ";
-        ctrs = true;
+        ccount++;
       } else {
         outh << "  void ";
         *outt << "void ";
@@ -753,7 +753,7 @@ void RamFuzz::run(const MatchFinder::MatchResult &Result) {
       else
         outh << cls << "()";
       outh << "; }\n";
-      ctrs = true;
+      ccount++;
     }
     for (const auto f : C->fields()) {
       const auto ty = f->getType();
@@ -770,8 +770,8 @@ void RamFuzz::run(const MatchFinder::MatchResult &Result) {
       }
     }
     gen_mroulette(cls, tmpl_preamble, namecount);
-    if (ctrs) {
-      gen_croulette(cls, tmpl_preamble, namecount[C->getNameAsString()]);
+    if (ccount) {
+      gen_croulette(cls, tmpl_preamble, ccount);
       outh << "  // Ctr safe from depthlimit; won't call another harness "
               "method.\n";
       outh << "  static constexpr cptr safectr = ";

--- a/lib/RamFuzz.cpp
+++ b/lib/RamFuzz.cpp
@@ -255,6 +255,13 @@ public:
     os << "template<" << templ_params(templ) << ">\n";
   }
 
+  string str() const {
+    string stemp;
+    raw_string_ostream rs(stemp);
+    rs << *this;
+    return rs.str();
+  }
+
 private:
   const ClassTemplateDecl *templ;
 };
@@ -775,10 +782,7 @@ void RamFuzz::run(const MatchFinder::MatchResult &Result) {
     outh << "};\n";
     outc << "\n";
     processed_classes.insert(cls);
-    string stemp;
-    raw_string_ostream rs(stemp);
-    rs << tmpl_preamble;
-    preambles_of_processed_classes[cls] = rs.str();
+    preambles_of_processed_classes[cls] = tmpl_preamble.str();
   }
 }
 

--- a/lib/RamFuzz.cpp
+++ b/lib/RamFuzz.cpp
@@ -641,11 +641,19 @@ void RamFuzz::gen_method(const Twine &hname, const CXXMethodDecl *M,
       *outt << "    return (this->*safectr)();\n";
       *outt << "  }\n";
     }
+    const auto parent = M->getParent();
     *outt << "  auto r = new ";
-    if (M->getParent()->isAbstract())
+    if (parent->isAbstract())
       *outt << "concrete_impl(g" << (M->param_empty() ? "" : ", ");
     else {
-      M->getParent()->printQualifiedName(*outt);
+      parent->printQualifiedName(*outt);
+      if (const auto t = parent->getDescribedClassTemplate()) {
+        *outt << '<';
+        const auto& params = *t->getTemplateParameters();
+        for (auto b = params.begin(), e = params.end(), i = b; i != e; ++i)
+          *outt << (i == b ? "" : ", ") << **i;
+        *outt << '>';
+      }
       *outt << "(";
     }
   } else {

--- a/lib/Util.cpp
+++ b/lib/Util.cpp
@@ -14,14 +14,28 @@
 
 #include "Util.hpp"
 
+#include "clang/AST/DeclTemplate.h"
+
 using namespace clang;
+
+namespace {
+
+/// Returns C's or its described template's (if one exists) AccessSpecifier.
+AccessSpecifier getAccess(const CXXRecordDecl *C) {
+  if (const auto t = C->getDescribedClassTemplate())
+    return t->getAccess();
+  else
+    return C->getAccess();
+}
+
+} // anonymous namespace
 
 bool globally_visible(const CXXRecordDecl *C) {
   if (!C || !C->getIdentifier())
     // Anonymous classes may technically be visible, but only through tricks
     // like decltype.  Skip until there's a compelling use-case.
     return false;
-  const auto acc = C->getAccess();
+  const auto acc = getAccess(C);
   if (acc == AS_private || acc == AS_protected)
     return false;
   const DeclContext *ctx = C->getLookupParent();

--- a/test/tmpl.cpp
+++ b/test/tmpl.cpp
@@ -1,0 +1,26 @@
+// Copyright 2016-2017 The RamFuzz contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fuzz.hpp"
+using namespace ramfuzz::runtime;
+int main(int argc, char *argv[]) {
+  gen g(argc, argv);
+  if (g.make<A<int>>()->plus1(123) != 124)
+    return 1;
+  if (g.make<A<float>>()->plus1(11.) != 12.)
+    return 1;
+  return g.make<A<unsigned>>()->plus1(0) != 1;
+}
+
+unsigned ::ramfuzz::runtime::spinlimit = 3;

--- a/test/tmpl.hpp
+++ b/test/tmpl.hpp
@@ -1,0 +1,21 @@
+// Copyright 2016-2017 The RamFuzz contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Tests generation of random instances of template classes.
+
+template<typename T>
+class A {
+public:
+  T plus1(T x) { return x + 1; }
+};

--- a/test/tmpl.hpp
+++ b/test/tmpl.hpp
@@ -17,5 +17,6 @@
 template<typename T>
 class A {
 public:
+  A(int) {}
   T plus1(T x) { return x + 1; }
 };


### PR DESCRIPTION
Generate RamFuzz code to support saying `Gen.make<Foo<int>>()` where `Foo` is a templated class.